### PR TITLE
chore(deps): bump highlight.js and @types/remarkable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/node": "20.8.0",
         "@types/react": "18.2.24",
         "@types/react-dom": "18.2.8",
-        "@types/remarkable": "2.0.4",
+        "@types/remarkable": "2.0.7",
         "npm-run-all": "4.1.5",
         "prettier": "3.0.3"
       }
@@ -2925,12 +2925,6 @@
         "@types/unist": "^2"
       }
     },
-    "node_modules/@types/highlight.js": {
-      "version": "9.12.4",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-      "dev": true
-    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -3013,14 +3007,10 @@
       }
     },
     "node_modules/@types/remarkable": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/remarkable/-/remarkable-2.0.4.tgz",
-      "integrity": "sha512-enyIahDSUuzOpnAuBtgzMRt60GoWS3fPAd2NOsn8yAX9MWqid8Z7bel1tELLSZXR6q0vyH2L7Vg24xYEKWjpMg==",
-      "dev": true,
-      "dependencies": {
-        "@types/highlight.js": "^9.7.0",
-        "highlight.js": "^9.7.0"
-      }
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/remarkable/-/remarkable-2.0.7.tgz",
+      "integrity": "sha512-yjt139N0JY5sDbRq2iXVbu+IM3BGHis7YtPOqETJZrbV6VYeQPNaHuTYIAqxTRdwul6eDBCNlh1Txiu5c4fj6w==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -5630,17 +5620,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -12216,12 +12195,6 @@
         "@types/unist": "^2"
       }
     },
-    "@types/highlight.js": {
-      "version": "9.12.4",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-      "dev": true
-    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -12304,14 +12277,10 @@
       }
     },
     "@types/remarkable": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/remarkable/-/remarkable-2.0.4.tgz",
-      "integrity": "sha512-enyIahDSUuzOpnAuBtgzMRt60GoWS3fPAd2NOsn8yAX9MWqid8Z7bel1tELLSZXR6q0vyH2L7Vg24xYEKWjpMg==",
-      "dev": true,
-      "requires": {
-        "@types/highlight.js": "^9.7.0",
-        "highlight.js": "^9.7.0"
-      }
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/remarkable/-/remarkable-2.0.7.tgz",
+      "integrity": "sha512-yjt139N0JY5sDbRq2iXVbu+IM3BGHis7YtPOqETJZrbV6VYeQPNaHuTYIAqxTRdwul6eDBCNlh1Txiu5c4fj6w==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "1.20.2",
@@ -14201,12 +14170,6 @@
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0"
       }
-    },
-    "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "20.8.0",
     "@types/react": "18.2.24",
     "@types/react-dom": "18.2.8",
-    "@types/remarkable": "2.0.4",
+    "@types/remarkable": "2.0.7",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.3"
   }


### PR DESCRIPTION
Removes [highlight.js](https://github.com/highlightjs/highlight.js). It's no longer used after updating ancestor dependency [@types/remarkable](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/remarkable). These dependencies need to be updated together.

Removes `highlight.js`

Updates `@types/remarkable` from 2.0.4 to 2.0.7
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/remarkable)

---
updated-dependencies:
- dependency-name: highlight.js dependency-type: indirect
- dependency-name: "@types/remarkable" dependency-type: direct:development ...